### PR TITLE
カレンダー詳細の雛形を変更/保存するためのoption pageの作成

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -17,7 +17,8 @@
   "permissions": [
     "tabs",
     "http://*/*",
-    "https://*/*"
+    "https://*/*",
+    "storage"
   ],
   "content_scripts": [
     {
@@ -31,5 +32,6 @@
       "run_at": "document_idle",
       "all_frames": false
     }
-  ]
+  ],
+  "options_page": "options.html"
 }

--- a/app/options.html
+++ b/app/options.html
@@ -6,8 +6,8 @@
     <script src="options.js"></script>
   </head>
   <body>
-    カレンダー詳細にいれたい雛形：
-    <input id="message" type="text">
+    カレンダー詳細にいれたい雛形：<br>
+    <textarea id="message" cols="40" rows="4"></textarea>
     <br>
 
     <input id="save" type="button" value="保存">

--- a/app/options.html
+++ b/app/options.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="bower_components/jquery/dist/jquery.min.js"></script>
+    <script src="options.js"></script>
+  </head>
+  <body>
+    カレンダー詳細にいれたい雛形：
+    <input id="message" type="text">
+    <br>
+
+    <input id="save" type="button" value="保存">
+  </body>
+</html>

--- a/app/options.js
+++ b/app/options.js
@@ -1,0 +1,18 @@
+$(function(){
+
+  // セーブボタンが押されたら、
+  // ローカルストレージに保存する。
+  var message = '';
+  $("#save").click(function () {
+    var tmpMessage = $('#message').val();
+    chrome.storage.local.set({'google_calender_detail_format': tmpMessage}, function () {
+      console.log(tmpMessage);
+      message = tmpMessage;
+    });
+  });
+
+  chrome.storage.local.get('google_calender_detail_format', function (value) {
+    message = value.google_calender_detail_format;
+    $("#message").val(message);
+  });
+});

--- a/app/scripts.babel/contentscript.js
+++ b/app/scripts.babel/contentscript.js
@@ -47,11 +47,21 @@ var observer = new MutationObserver(function(mutations) {
           {
             console.log('変更する必要ある');
             chrome.storage.local.get('google_calender_detail_format', function (value) {
-              console.log(value);
+              console.log(value.google_calender_detail_format);
               if (value.google_calender_detail_format)
               {
                 $scheduleDummyDOM.text('');
-                $scheduleDescDOM.text(value.google_calender_detail_format);
+                var arr = value.google_calender_detail_format.split(/\r\n|\r|\n/);
+                for (var i = 0; i < arr.length; i++) {
+                  if (i === 0)
+                  {
+                    $scheduleDescDOM.text(arr[0]);
+                  }
+                  else
+                  {
+                    $scheduleDescDOM.append('<div>' + arr[i] + '</div>')
+                  }
+                }
               }
             });
           }

--- a/app/scripts.babel/contentscript.js
+++ b/app/scripts.babel/contentscript.js
@@ -46,9 +46,14 @@ var observer = new MutationObserver(function(mutations) {
           else
           {
             console.log('変更する必要ある');
-            // NOTE : 暫定対応
-            $scheduleDummyDOM.text('');
-            $scheduleDescDOM.text('changed text');
+            chrome.storage.local.get('google_calender_detail_format', function (value) {
+              console.log(value);
+              if (value.google_calender_detail_format)
+              {
+                $scheduleDummyDOM.text('');
+                $scheduleDescDOM.text(value.google_calender_detail_format);
+              }
+            });
           }
         }
       },100);


### PR DESCRIPTION
## 概要
カレンダー詳細に表示するtextをいじれるoptionページの作成とその結果をlocalStorageに保存できるようにした